### PR TITLE
Dependencies fix

### DIFF
--- a/packages/shared/composer.json
+++ b/packages/shared/composer.json
@@ -23,7 +23,7 @@
   "require": {
     "php": "^7.1",
     "psr/http-message": "^1.0",
-    "prooph/common": "4.0.x-dev",
+    "prooph/common": "^4.0",
     "mongodb/mongodb": "^1.0"
   },
   "require-dev": {

--- a/service/user-read/composer.json
+++ b/service/user-read/composer.json
@@ -21,13 +21,13 @@
   ],
   "require": {
     "php": "^7.1",
-    "prooph/common": "4.0.x-dev",
-    "prooph/event-store": "7.0.x-dev",
-    "prooph/pdo-event-store": "1.0.x-dev"
+    "prooph/common": "^4.0",
+    "prooph/event-store": "^7.0",
+    "prooph/pdo-event-store": "^1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^5.7",
-    "phpspec/prophecy": "dev-patch-1 as 1.6.2",
+    "phpspec/prophecy": "1.7.0",
     "prooph/php-cs-fixer-config": "^0.1.1",
     "satooshi/php-coveralls": "^1.0",
     "malukenho/docheader": "^0.1.4"
@@ -46,11 +46,5 @@
     "cs": "php-cs-fixer fix -v --diff --dry-run",
     "cs-fix": "php-cs-fixer fix -v --diff",
     "test": "vendor/bin/phpunit"
-  },
-  "repositories": [
-    {
-      "type": "git",
-      "url": "https://github.com/prolic/prophecy.git"
-    }
-  ]
+  }
 }

--- a/service/user-write/composer.json
+++ b/service/user-write/composer.json
@@ -23,7 +23,7 @@
     "php": "^7.1",
     "prooph-micro-do/shared": "^1.0",
     "roave/security-advisories": "dev-master",
-    "prooph/common": "4.0.x-dev",
+    "prooph/common": "^4.0",
     "prooph/event-store": "7.0.x-dev",
     "prooph/pdo-event-store": "1.0.x-dev",
     "prooph/micro": "dev-master",
@@ -35,7 +35,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^5.7",
-    "phpspec/prophecy": "dev-patch-1 as 1.6.2",
+    "phpspec/prophecy": "^1.7.0",
     "prooph/php-cs-fixer-config": "^0.1.1",
     "satooshi/php-coveralls": "^1.0",
     "malukenho/docheader": "^0.1.4"
@@ -67,10 +67,6 @@
       "options": {
         "symlink": false
       }
-    },
-    {
-      "type": "git",
-      "url": "https://github.com/prolic/prophecy.git"
     }
   ]
 }


### PR DESCRIPTION
Hi! I've been playing around with your solution but clashed some problems during installation. Maybe I'm doing something wrong but when I try to follow your installation instructions, `composer install` fails with errors like:
```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - The requested package phpspec/prophecy dev-patch-1 as 1.6.2 exists as phpspec/prophecy[v1.1.2, v1.4.0, dev-master, 1.7.x-dev, v1.0.0, v1.0.0-BETA1, v1.0.0-BETA2, v1.0.1, v1.0.2, v1.0.3, v1.0.4, v1.1.0, v1.1.1, v1.2.0, v1.2.1, v1.3.0, v1.3.1, v1.4.1, v1.5.0, v1.6.0, v1.6.1, v1.6.2, v1.7.0, 1.6.x-dev] but these are rejected by your constraint.
```

And there are some other issues in composer.json files which leads to errors. I just replaced previously specified versions by the newer and MORE STABLE versions of the packages. I hope it can help to someone like me who wants just to play with your solution without any modifications.